### PR TITLE
spring-boot-web-sample to 1.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.1
 - name: spring-boot-web-sample
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.1
+  version: 1.0.2


### PR DESCRIPTION
Promote spring-boot-web-sample to version 1.0.2